### PR TITLE
Replace wildcard imports with explicit imports

### DIFF
--- a/Stitcher.glyphsFilter/Contents/Info.plist
+++ b/Stitcher.glyphsFilter/Contents/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleName</key>
 	<string>Stitcher</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>UpdateFeedURL</key>
 	<string>https://raw.githubusercontent.com/mekkablue/Stitcher/master/Stitcher.glyphsFilter/Contents/Info.plist</string>
 	<key>productPageURL</key>

--- a/Stitcher.glyphsFilter/Contents/Resources/plugin.py
+++ b/Stitcher.glyphsFilter/Contents/Resources/plugin.py
@@ -16,8 +16,8 @@ from __future__ import division, print_function, unicode_literals
 ###########################################################################################################
 
 import objc
-from GlyphsApp import *
-from GlyphsApp.plugins import *
+from GlyphsApp import Glyphs, GSComponent, GSPath, OFFCURVE
+from GlyphsApp.plugins import FilterWithDialog
 from math import hypot, atan2, cos, sin, pi
 from AppKit import NSAffineTransform, NSPoint
 


### PR DESCRIPTION
Follows the recent import-cleanup pattern applied across the Glyphs plug-in repos: replace wildcard imports with explicit ones.

### Changes
- `from GlyphsApp import *` → `from GlyphsApp import Glyphs, GSComponent, GSPath, OFFCURVE`
- `from GlyphsApp.plugins import *` → `from GlyphsApp.plugins import FilterWithDialog`
- Version bump: `CFBundleVersion` 14 → 15, `CFBundleShortVersionString` 2.1.2 → 2.1.3

`import objc`, the `math` imports and `from AppKit import NSAffineTransform, NSPoint` were already explicit. No behavioural change; only the imports are made explicit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs2JtfNiM4z5Duepf74nqX)_